### PR TITLE
Add request()->validate() macro

### DIFF
--- a/source/Http/Request.php
+++ b/source/Http/Request.php
@@ -2,6 +2,9 @@
 
 namespace Next\Http;
 
+/**
+ * @method \Rakit\Validation\Validation validate(array $rules = [], array $messages = [])
+ */
 class Request extends \Illuminate\Http\Request
 {
     protected $params;

--- a/source/Validation/Proxy.php
+++ b/source/Validation/Proxy.php
@@ -9,7 +9,15 @@ class Proxy
     
     public static function connect(\Next\App $app)
     {
-        static::$connection = new \Rakit\Validation\Validator();
+        static::$connection = $connection = new \Rakit\Validation\Validator();
+
+        \Next\Http\Request::macro('validate', function (array $rules = [], array $messages = []) use ($connection) {
+            $validation = $connection->make($this->only(array_keys($rules)), $rules, $messages);
+
+            $validation->validate();
+
+            return $validation;
+        });
     }
 
     public function run(\Next\Http\Request $request, array $rules = [])


### PR DESCRIPTION
This adds a new `validate()` macro to `\Next\Http\Request`.

The macro will automatically run the validation against the request when
it is called (no need to call `$validation->validate()`). It will also
infer what request parameters to validate by reading the keys from your
rules.

If you want to use different error messages to the default then you may
specify them as a second argument to `validate()`.

The validation macro is registered within Next\Validation\Proxy so that
if you remove the validation proxy from your application config then the
validation will cease to function. There will be no need to check
whether there is a validation instance available, like you would have to
do if it was a dedicated method directly on the `Next\Http\Request`
class.