### PR TITLE
Create Next\Console\Application and Next\Console\Command

### DIFF
--- a/source/Console/Application.php
+++ b/source/Console/Application.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Next\Console;
+
+class Application extends \Symfony\Component\Console\Application
+{
+    private \Next\App $app;
+
+    public function __construct(\Next\App $app)
+    {
+        parent::__construct('Next Framework');
+
+        (new \NunoMaduro\Collision\Provider())->register();
+
+        $this->app = $app;
+    }
+
+    public function get(string $name): \Symfony\Component\Console\Command\Command
+    {
+        $command = parent::get($name);
+
+        if ($command instanceof \Next\Console\Command) {
+            $command->setApp($this->app);
+        }
+
+        return $command;
+    }
+}

--- a/source/Console/Command.php
+++ b/source/Console/Command.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Next\Console;
+
+use Next\App;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+abstract class Command extends \Symfony\Component\Console\Command\Command
+{
+    protected App $app;
+
+    protected string $signature = '';
+
+    protected string $description = '';
+
+    protected string $help = '';
+
+    protected InputInterface $input;
+
+    protected OutputInterface $output;
+
+    public function __construct()
+    {
+        [$name, $arguments, $options] = Parser::parse($this->signature);
+
+        parent::__construct($name);
+
+        $this->setHelp($this->help);
+        $this->setDescription($this->description);
+
+        $this->getDefinition()->addArguments($arguments);
+        $this->getDefinition()->addOptions($options);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->input = $input;
+
+        $this->output = new SymfonyStyle($input, $output);
+
+        return (int) $this->app->call([$this, 'handle']);
+    }
+
+    public function setApp(App $app)
+    {
+        $this->app = $app;
+    }
+
+    protected function hasArgument(string $name): bool
+    {
+        return $this->input->hasArgument($name);
+    }
+
+    protected function argument(string $key): string|array|null
+    {
+        return $this->input->getArgument($key);
+    }
+
+    protected function arguments(): array
+    {
+        return $this->input->getArguments();
+    }
+
+    protected function hasOption(string $name): bool
+    {
+        return $this->input->hasOption($name);
+    }
+
+    protected function option(string $name): string|array|bool|null
+    {
+        return $this->input->getOption($name);
+    }
+
+    protected function options(): array
+    {
+        return $this->input->getOptions();
+    }
+
+    protected function parseVerbosity(int|string|null $level = null): int
+    {
+        $levels = [
+            'v' => OutputInterface::VERBOSITY_VERBOSE,
+            'vv' => OutputInterface::VERBOSITY_VERY_VERBOSE,
+            'vvv' => OutputInterface::VERBOSITY_DEBUG,
+            'quiet' => OutputInterface::VERBOSITY_QUIET,
+            'normal' => OutputInterface::VERBOSITY_NORMAL,
+        ];
+
+        if (array_key_exists($level, $levels)) {
+            return $levels[$level];
+        }
+
+        if (! is_int($level)) {
+            return $levels['normal'];
+        }
+
+        return $level;
+    }
+
+    protected function confirm(string $question, bool $default = false): bool
+    {
+        return $this->output->confirm($question, $default);
+    }
+
+    public function ask(string $question, string|null $default = null): mixed
+    {
+        return $this->output->ask($question, $default);
+    }
+
+    protected function line(string $message, string $style = null, string|int|null $verbosity = null): void
+    {
+        $message = $style ? "<$style>$message</$style>" : $message;
+
+        $this->output->writeln($message, $this->parseVerbosity($verbosity));
+    }
+
+    protected function info(string $message, string|int $verbosity = null): void
+    {
+        $this->line($message, 'info', $verbosity);
+    }
+
+    protected function comment(string $message, string|int $verbosity = null): void
+    {
+        $this->line($message, 'comment', $verbosity);
+    }
+
+    protected function question(string $question, string|int $verbosity = null): void
+    {
+        $this->line($question, 'question', $verbosity);
+    }
+
+    protected function error(string $error, string|int $verbosity = null): void
+    {
+        $this->line($error, 'error', $verbosity);
+    }
+
+    public function warn(string $string, string|int $verbosity = null): void
+    {
+        $this->line($string, 'warning', $verbosity);
+    }
+}

--- a/source/Console/Parser.php
+++ b/source/Console/Parser.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Next\Console;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Based on Laravel 8's console component.
+ */
+final class Parser
+{
+    /**
+     * Parse the given console command definition into an array.
+     *
+     * @param  string  $expression
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function parse(string $expression): array
+    {
+        $name = self::name($expression);
+
+        if (preg_match_all('/{\s*(.*?)\s*}/', $expression, $matches)) {
+            if (count($matches[1])) {
+                return array_merge([$name], self::parameters($matches[1]));
+            }
+        }
+
+        return [$name, [], []];
+    }
+
+    /**
+     * Extract the name of the command from the expression.
+     *
+     * @param  string  $expression
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    protected static function name(string $expression): string
+    {
+        if (!preg_match('/[^\s]+/', $expression, $matches)) {
+            throw new InvalidArgumentException('Unable to determine command name from signature.');
+        }
+
+        return $matches[0];
+    }
+
+    /**
+     * Extract all of the parameters from the tokens.
+     *
+     * @param  array  $tokens
+     * @return array
+     */
+    protected static function parameters(array $tokens): array
+    {
+        $arguments = [];
+
+        $options = [];
+
+        foreach ($tokens as $token) {
+            if (preg_match('/-{2,}(.*)/', $token, $matches)) {
+                $options[] = self::parseOption($matches[1]);
+            } else {
+                $arguments[] = self::parseArgument($token);
+            }
+        }
+
+        return [$arguments, $options];
+    }
+
+    /**
+     * Parse an argument expression.
+     *
+     * @param  string  $token
+     * @return InputArgument
+     */
+    protected static function parseArgument(string $token): InputArgument
+    {
+        [$token, $description] = self::extractDescription($token);
+
+        switch (true) {
+            case Str::endsWith($token, '?*'):
+                return new InputArgument(trim($token, '?*'), InputArgument::IS_ARRAY, $description);
+            case Str::endsWith($token, '*'):
+                return new InputArgument(
+                    trim($token, '*'),
+                    InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+                    $description
+                );
+            case Str::endsWith($token, '?'):
+                return new InputArgument(trim($token, '?'), InputArgument::OPTIONAL, $description);
+            case preg_match('/(.+)=\*(.+)/', $token, $matches):
+                return new InputArgument(
+                    $matches[1],
+                    InputArgument::IS_ARRAY,
+                    $description,
+                    preg_split('/,\s?/', $matches[2])
+                );
+            case preg_match('/(.+)=(.+)/', $token, $matches):
+                return new InputArgument($matches[1], InputArgument::OPTIONAL, $description, $matches[2]);
+            default:
+                return new InputArgument($token, InputArgument::REQUIRED, $description);
+        }
+    }
+
+    /**
+     * Parse an option expression.
+     *
+     * @param  string  $token
+     * @return InputOption
+     */
+    protected static function parseOption(string $token): InputOption
+    {
+        [$token, $description] = self::extractDescription($token);
+
+        $matches = preg_split('/\s*\|\s*/', $token, 2);
+
+        if (isset($matches[1])) {
+            $shortcut = $matches[0];
+            $token = $matches[1];
+        } else {
+            $shortcut = null;
+        }
+
+        switch (true) {
+            case Str::endsWith($token, '='):
+                return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
+            case Str::endsWith($token, '=*'):
+                return new InputOption(
+                    trim($token, '=*'),
+                    $shortcut,
+                    InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                    $description
+                );
+            case preg_match('/(.+)=\*(.+)/', $token, $matches):
+                return new InputOption(
+                    $matches[1],
+                    $shortcut,
+                    InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                    $description,
+                    preg_split('/,\s?/', $matches[2])
+                );
+            case preg_match('/(.+)=(.+)/', $token, $matches):
+                return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]);
+            default:
+                return new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description);
+        }
+    }
+
+    /**
+     * Parse the token into its token and description segments.
+     *
+     * @param  string  $token
+     * @return array
+     */
+    protected static function extractDescription(string $token): array
+    {
+        $parts = preg_split('/\s+:\s+/', trim($token), 2);
+
+        return count($parts) === 2 ? $parts : [$token, ''];
+    }
+}

--- a/source/Database/Commands/MigrateCommand.php
+++ b/source/Database/Commands/MigrateCommand.php
@@ -1,27 +1,20 @@
 <?php
 
-namespace Next\Commands;
+namespace Next\Database\Commands;
 
-class MigrateCommand extends \Symfony\Component\Console\Command\Command
+class MigrateCommand extends \Next\Console\Command
 {
-    protected static $defaultName = 'migrate';
+    protected string $signature = 'migrate';
 
-    protected function configure()
-    {
-        // TODO
-    }
+    protected string $description = 'Migrate the database';
 
-    protected function execute(
-        \Symfony\Component\Console\Input\InputInterface $input,
-        \Symfony\Component\Console\Output\OutputInterface $output
-    ) {
-        $connection = \Next\App::getInstance()->make(\Next\Database::class);
-
+    public function handle(\Next\Database $connection) {
         $count = 0;
-        $output->writeln('Migrating');
+        $this->line('Migrating');
 
         if (!$connection->schema()->hasTable('migrations')) {
-            $output->writeln('Creating migrations table');
+            $this->info('No migrations table found.');
+            $this->line('Creating migrations table');
 
             $connection->schema()->create('migrations', function ($table) {
                 $table->string('name')->unique();
@@ -44,7 +37,7 @@ class MigrateCommand extends \Symfony\Component\Console\Command\Command
             }
 
             $count++;
-            $output->writeln("Migrating {$name}");
+            $this->info("Migrating {$name}");
 
             $runner = require $migration;
             $runner($connection);
@@ -53,14 +46,14 @@ class MigrateCommand extends \Symfony\Component\Console\Command\Command
         }
 
         if ($count == 0) {
-            $output->writeln('No migrations to run');
+            $this->line('No migrations to run');
         } elseif ($count == 1) {
-            $output->writeln("{$count} migration run");
+            $this->line("{$count} migration run");
         } else {
-            $output->writeln("{$count} migrations run");
+            $this->line("{$count} migrations run");
         }
 
-        $output->writeln('Done');
+        $this->line('Done');
 
         return \Symfony\Component\Console\Command\Command::SUCCESS;
     }


### PR DESCRIPTION
The new \Next\Console\Application extends the Symfony console
application so it can be a drop-in replacement to the current console.

Application will automatically register the Collision error handler, so
that can be removed from the application. Also, the Application will set
an instance of \Next\App on any console command that extends
\Next\Console\Command.

You don't have to extend \Next\Console\Command so we can still utilise
3rd party commands extending \Symfony\Components\Console\Command\Command.

If your command extends \Next\Console\Command you must define a
`handle()` method instead of using the usual `execute()` method you
would with a Symfony command. This is because we have overwritten the
`execute()` command to utilise the `\Next\App` instance to inject any
dependencies specified in the `handle()` method signature. For example:

```
public function handle(LoggerInterface $logger) {
    // Interact with the logger
}
```

You may be wondering how you will interact with the input and output if
they're not passed through the handle method, as that is what you're
used to if you're familiar with Symfony commands. Well, there are now
some nice methods on the command for interacting with IO.

- `$this->argument('name');`
- `$this->option('name');`
- `$this->ask('question');`
- `$this->confirm('question');`
- `$this->info('message');`
- `$this->comment('comment');`
- `$this->warn('message');`
- etc.

If there is anything that isn't covered by the new IO API then you have
a couple new properties available to you `$this->input` and
`$this->output`.