### PR TITLE
Inject dependencies for request handlers

### DIFF
--- a/source/App.php
+++ b/source/App.php
@@ -106,7 +106,7 @@ class App extends \Illuminate\Container\Container
 
                 $collector->addRoute('*', "{$apiFilePath}/{$apiFileName}", [
                     'type' => 'api',
-                    'factory' => require $apiFile,
+                    'factory' => fn () => $this->call(require $apiFile),
                 ]);
             }
 
@@ -128,7 +128,7 @@ class App extends \Illuminate\Container\Container
 
                 $collector->addRoute('GET', "{$pageFilePath}/{$pageFileName}", [
                     'type' => 'page',
-                    'factory' => require $pageFile,
+                    'factory' => fn () => $this->call(require $pageFile),
                 ]);
             }
         });


### PR DESCRIPTION
This will allow you to specify any dependencies you want in a
page/request handler callback's arguments. For example:

```
return function (Cache $cache) {
  $posts = $cache->remember('posts', fn () => Post::all(), 5);

  return response()->json($posts);
}
```