### PR TITLE
Allow configurable middleware to be added to config

### DIFF
--- a/source/Middleware/Runner.php
+++ b/source/Middleware/Runner.php
@@ -27,6 +27,10 @@ class Runner
         $current = array_shift($this->middleware);
         $next = clone $this;
 
-        return $this->app->make($current)->handle($request, $next);
+        if (! is_object($current)) {
+            $current = $this->app->make($current);
+        }
+
+        return $current->handle($request, $next);
     }
 }


### PR DESCRIPTION
In my experience I've seen some middleware that allows you to configure
it. These tend to not have any dependencies so can be instantiated
before being pushed into the middleware queue. After instantiation you
can call methods on the middleware to alter it's behaviour.

```
return [
    // ...
    'middleware' => [
        \Next\Middleware\SessionMiddleware::class,
	(new \Next\Middleware\Cors())
	    ->origin('*')
	    ->methods(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
    ],
    // ...
];
```