### PR TITLE
Ensure Cache::remember only calls closure once

### DIFF
--- a/source/Cache/Proxy.php
+++ b/source/Cache/Proxy.php
@@ -70,9 +70,14 @@ class Proxy
         return $default;
     }
 
-    public function remember(string $key, \Closure $factory, int $seconds = null): mixed
+    public function remember(string $key, callable $factory, int $seconds = null): mixed
     {
+        if ($this->has($key)) {
+            return $this->get($key);
+        }
+
         $this->store($key, $value = $factory(), $seconds);
+
         return $value;
     }
 

--- a/tests/Unit/CacheTest.php
+++ b/tests/Unit/CacheTest.php
@@ -58,6 +58,27 @@ test('cache can remember', function () use ($defaults) {
     $this->assertEquals($cache->get('i-can-remember'), null);
 });
 
+test('cache remember only calls closure once', function () use ($defaults) {
+    $app = new \Next\App($defaults);
+
+    $cache = $app[\Next\Cache::class];
+
+    $closure = $this
+        ->getMockBuilder(\stdClass::class)
+        ->addMethods(['__invoke'])
+        ->getMock();
+
+    $closure
+        ->expects($this->once())
+        ->method('__invoke')
+        ->willReturn('i can remember');
+
+    $cache->remember('i-only-get-called-once', $closure, 1);
+
+    $this->assertEquals('i can remember', $cache->remember('i-only-get-called-once', $closure, 1));
+    $this->assertEquals('i can remember', $cache->remember('i-only-get-called-once', $closure, 1));
+});
+
 test('cache can remember forever', function () use ($defaults) {
     $app = new \Next\App($defaults);
 


### PR DESCRIPTION
The initial intention for Cache::remember was to be an alias to
Cache::store that accepted a closure. However, after talking to
@assertchris we agreed that it should return the cached value instead of
calling the closure each time.

In order to get the test to pass I had to change the type of `$factory`
from `\Closure` to `callable`. This only adds support for any class that
defines an `__invoke` method and still supports regular `Closure`s so
this change should be okay.