### PR TITLE
Add overwritable error pages for common errors.

### DIFF
--- a/source/Http/MissingContentNegotiator.php
+++ b/source/Http/MissingContentNegotiator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Next\Http;
+
+final class MissingContentNegotiator extends \RuntimeException
+{
+    public static function forMethod(string $method): MissingContentNegotiator
+    {
+        return new self("No content negotiator for {$method}");
+    }
+}

--- a/source/Http/RequestMethodNegotiator.php
+++ b/source/Http/RequestMethodNegotiator.php
@@ -99,6 +99,9 @@ class RequestMethodNegotiator
             ->header('Allow', implode(', ', array_keys(array_filter($this->handlers))));
     }
 
+    /**
+     * @throws MissingContentNegotiator
+     */
     public function negotiate(string $method): mixed
     {
         $method = strtoupper($method);
@@ -111,6 +114,6 @@ class RequestMethodNegotiator
             return ($this->default)();
         }
 
-        throw new \RuntimeException("No content negotiator for {$method}");
+        throw MissingContentNegotiator::forMethod($method);
     }
 }

--- a/source/Http/ResponseTypeNegotiator.php
+++ b/source/Http/ResponseTypeNegotiator.php
@@ -32,6 +32,9 @@ class ResponseTypeNegotiator
         return $this;
     }
 
+    /**
+     * @throws UnsupportedContentType
+     */
     public function negotiate(string $extension): mixed
     {
         if (array_key_exists($extension, $this->handlers)) {
@@ -42,6 +45,6 @@ class ResponseTypeNegotiator
             return ($this->default)();
         }
 
-        throw new \RuntimeException("File extension {$extension} not supported");
+        throw UnsupportedContentType::forFileType($extension);
     }
 }

--- a/source/Http/UnsupportedContentType.php
+++ b/source/Http/UnsupportedContentType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Next\Http;
+
+final class UnsupportedContentType extends \RuntimeException
+{
+    public static function forFileType(string $fileType): self
+    {
+        return new self("File extension {$fileType} not supported");
+    }
+}

--- a/source/Testing/TestResponse.php
+++ b/source/Testing/TestResponse.php
@@ -80,6 +80,19 @@ class TestResponse
         return $this;
     }
 
+    public function assertStatus(int $expectedStatus): self
+    {
+        $actualStatus = $this->getStatusCode();
+
+        \PHPUnit\Framework\Assert::assertSame(
+            $expectedStatus,
+            $actualStatus,
+            "Status [{$expectedStatus}] does not match actual status [{$actualStatus}].",
+        );
+
+        return $this;
+    }
+
     public function __get(string $key): mixed
     {
         return $this->baseResponse->{$key};

--- a/tests/Feature/ContentNegotiationTest.php
+++ b/tests/Feature/ContentNegotiationTest.php
@@ -41,15 +41,13 @@ it('calls POST handler')
     ->post('/api/nomadic-content-negotiation')
     ->assertSee('POST handler');
 
-// TODO: we should get a 405 error instead.
 it('throws exception by default when method not negotiated')
-    ->expectException(\RuntimeException::class)
-    ->delete('/api/nomadic-content-negotiation');
+    ->delete('/api/nomadic-content-negotiation')
+    ->assertStatus(405);
 
-// TODO: we should get a 415 error instead.
 it('throws exception by default when content type is not negotiated')
-    ->expectException(\RuntimeException::class)
-    ->get('/api/nomadic-content-negotiation.pdf');
+    ->get('/api/nomadic-content-negotiation.pdf')
+    ->assertStatus(415);
 
 it('calls default handler when method not negotiated')
     ->post('/api/nomadic-content-negotiation-with-defaults')

--- a/tests/Feature/ErrorPagesTest.php
+++ b/tests/Feature/ErrorPagesTest.php
@@ -1,0 +1,57 @@
+<?php
+
+test('A missing route results in a 404 response')
+    ->get('/missing-route')
+    ->assertStatus(404)
+    ->assertSee('Not found.');
+
+test('The incorrect METHOD results in a 405 response')
+    ->withPages([
+        'page.php' => '<?php return fn() => "Never executed";',
+    ])
+    ->post('/page')
+    ->assertStatus(405)
+    ->assertSee('Method not allowed.');
+
+test('An exception thrown results in a 500 response')
+    ->withPages([
+        'error.php' => '<?php return fn () => throw new \RuntimeException();'
+    ])
+    ->get('/error')
+    ->assertStatus(500)
+    ->assertSee('Something went wrong.', false);
+
+test('The default 404 error page can be overwritten')
+    ->withPages([
+        '_404.php' => '<?php return fn () => \Next\Http\Response::create("This is not the page you\'re looking for!", 404);',
+    ])
+    ->get('/missing-route')
+    ->assertStatus(404)
+    ->assertSee('This is not the page you\'re looking for!', false);
+
+test('The default 405 error page can be overwritten')
+    ->withPages([
+        '_405.php' => '<?php return fn () => \Next\Http\Response::create("This is not the page you\'re looking for!", 405);',
+        'post.php' => '<?php return fn () => request()->when()->post(fn () => "Hello");'
+    ])
+    ->get('/post')
+    ->assertStatus(405)
+    ->assertSee('This is not the page you\'re looking for!', false);
+
+test('The default 415 error page can be overwritten')
+    ->withPages([
+        '_415.php' => '<?php return fn () => \Next\Http\Response::create("This is not the page you\'re looking for!", 415);',
+        'post.php' => '<?php return fn () => response()->for()->json(fn () => response()->json(["hello"]));'
+    ])
+    ->get('/post')
+    ->assertStatus(415)
+    ->assertSee('This is not the page you\'re looking for!', false);
+
+test('The default 500 error page can be overwritten')
+    ->withPages([
+        '_500.php' => '<?php return fn () => \Next\Http\Response::create("Something went really wrong!", 500);',
+        'error.php' => '<?php return fn () => throw new \RuntimeException();'
+    ])
+    ->get('/error')
+    ->assertStatus(500)
+    ->assertSee('Something went really wrong!', false);


### PR DESCRIPTION
I've added overwritable error responses for common errors. Next will now listen for a few specific errors and serve up a generic error page which can be replaced with an application specific alternative. All you have to do within your application is define a `_404.php`, `_405.php`, `_415.php`, or `_500.php` file at the root of your `pages/` directory and it'll replace the framework error pages. 

I did this work but completely missed the `Next\Errors` proxy. I'm not entirely sure how that is supposed to work so I've submitted my changes anyway. Could you give me some direction as to whether you want to replace the existing stuff, whether I've gone the wrong direction, or maybe they're actually serving different purposes.